### PR TITLE
Catch additional exception

### DIFF
--- a/src/plugins/PluginManager.cs
+++ b/src/plugins/PluginManager.cs
@@ -83,6 +83,10 @@ public class PluginManager
 		catch (DirectoryNotFoundException e) {
 			System.Console.WriteLine(e.Message);
 		}
+                catch (System.IO.IOException e) {
+			System.Console.WriteLine(e.Message);
+                        System.Console.WriteLine("plugins directory may not exist");
+                }
 
 	}
 


### PR DESCRIPTION
Fix for unhandled exception in case userPluginDir is a file instead of a directory.