### PR TITLE
Add 64 bit signed and unsigned conversations

### DIFF
--- a/data/ui/ConversionTablePlugin.ui
+++ b/data/ui/ConversionTablePlugin.ui
@@ -33,8 +33,8 @@
         </child>
       </object>
       <packing>
-        <property name="left_attach">6</property>
-        <property name="right_attach">7</property>
+        <property name="left_attach">8</property>
+        <property name="right_attach">9</property>
         <property name="x_options">GTK_FILL</property>
         <property name="y_options"/>
       </packing>
@@ -53,8 +53,8 @@
         </child>
       </object>
       <packing>
-        <property name="left_attach">5</property>
-        <property name="right_attach">6</property>
+        <property name="left_attach">7</property>
+        <property name="right_attach">8</property>
         <property name="top_attach">4</property>
         <property name="bottom_attach">5</property>
         <property name="y_options"/>
@@ -74,8 +74,8 @@
         </child>
       </object>
       <packing>
-        <property name="left_attach">5</property>
-        <property name="right_attach">6</property>
+        <property name="left_attach">7</property>
+        <property name="right_attach">8</property>
         <property name="top_attach">2</property>
         <property name="bottom_attach">3</property>
         <property name="y_options"/>
@@ -95,8 +95,8 @@
         </child>
       </object>
       <packing>
-        <property name="left_attach">5</property>
-        <property name="right_attach">6</property>
+        <property name="left_attach">7</property>
+        <property name="right_attach">8</property>
         <property name="top_attach">1</property>
         <property name="bottom_attach">2</property>
         <property name="y_options"/>
@@ -116,8 +116,8 @@
         </child>
       </object>
       <packing>
-        <property name="left_attach">5</property>
-        <property name="right_attach">6</property>
+        <property name="left_attach">7</property>
+        <property name="right_attach">8</property>
         <property name="y_options"/>
       </packing>
     </child>
@@ -127,8 +127,8 @@
         <property name="editable">False</property>
       </object>
       <packing>
-        <property name="left_attach">5</property>
-        <property name="right_attach">6</property>
+        <property name="left_attach">7</property>
+        <property name="right_attach">8</property>
         <property name="top_attach">3</property>
         <property name="bottom_attach">4</property>
         <property name="y_options"/>
@@ -141,8 +141,8 @@
         <property name="label" translatable="yes">ASCII Text:</property>
       </object>
       <packing>
-        <property name="left_attach">4</property>
-        <property name="right_attach">5</property>
+        <property name="left_attach">6</property>
+        <property name="right_attach">7</property>
         <property name="top_attach">4</property>
         <property name="bottom_attach">5</property>
         <property name="x_options">GTK_FILL</property>
@@ -209,10 +209,10 @@
         </child>
       </object>
       <packing>
-        <property name="left_attach">3</property>
-        <property name="right_attach">4</property>
-        <property name="top_attach">3</property>
-        <property name="bottom_attach">4</property>
+        <property name="left_attach">5</property>
+        <property name="right_attach">6</property>
+        <property name="top_attach">2</property>
+        <property name="bottom_attach">3</property>
         <property name="y_options"/>
       </packing>
     </child>
@@ -274,6 +274,46 @@
       <packing>
         <property name="left_attach">3</property>
         <property name="right_attach">4</property>
+        <property name="y_options"/>
+      </packing>
+    </child>
+    <child>
+      <object class="GtkAlignment" id="alignment34_2">
+        <property name="visible">True</property>
+        <property name="xalign">0</property>
+        <property name="xscale">0</property>
+        <child>
+          <object class="GtkEntry" id="Unsigned64bitEntry">
+            <property name="visible">True</property>
+            <property name="editable">False</property>
+            <property name="width_chars">16</property>
+          </object>
+        </child>
+      </object>
+      <packing>
+        <property name="left_attach">5</property>
+        <property name="right_attach">6</property>
+        <property name="top_attach">1</property>
+        <property name="bottom_attach">2</property>
+        <property name="y_options"/>
+      </packing>
+    </child>
+    <child>
+      <object class="GtkAlignment" id="alignment33_2">
+        <property name="visible">True</property>
+        <property name="xalign">0</property>
+        <property name="xscale">0</property>
+        <child>
+          <object class="GtkEntry" id="Signed64bitEntry">
+            <property name="visible">True</property>
+            <property name="editable">False</property>
+            <property name="width_chars">16</property>
+          </object>
+        </child>
+      </object>
+      <packing>
+        <property name="left_attach">5</property>
+        <property name="right_attach">6</property>
         <property name="y_options"/>
       </packing>
     </child>
@@ -366,8 +406,8 @@
         <property name="label" translatable="yes">Binary:</property>
       </object>
       <packing>
-        <property name="left_attach">4</property>
-        <property name="right_attach">5</property>
+        <property name="left_attach">6</property>
+        <property name="right_attach">7</property>
         <property name="top_attach">3</property>
         <property name="bottom_attach">4</property>
         <property name="x_options">GTK_FILL</property>
@@ -382,8 +422,8 @@
         <property name="label" translatable="yes">Octal:</property>
       </object>
       <packing>
-        <property name="left_attach">4</property>
-        <property name="right_attach">5</property>
+        <property name="left_attach">6</property>
+        <property name="right_attach">7</property>
         <property name="top_attach">2</property>
         <property name="bottom_attach">3</property>
         <property name="x_options">GTK_FILL</property>
@@ -398,8 +438,8 @@
         <property name="label" translatable="yes">Decimal:</property>
       </object>
       <packing>
-        <property name="left_attach">4</property>
-        <property name="right_attach">5</property>
+        <property name="left_attach">6</property>
+        <property name="right_attach">7</property>
         <property name="top_attach">1</property>
         <property name="bottom_attach">2</property>
         <property name="x_options">GTK_FILL</property>
@@ -414,8 +454,8 @@
         <property name="label" translatable="yes">Hexadecimal:</property>
       </object>
       <packing>
-        <property name="left_attach">4</property>
-        <property name="right_attach">5</property>
+        <property name="left_attach">6</property>
+        <property name="right_attach">7</property>
         <property name="x_options">GTK_FILL</property>
         <property name="y_options"/>
         <property name="x_padding">6</property>
@@ -428,16 +468,49 @@
         <property name="label" translatable="yes">Float 64 bit:</property>
       </object>
       <packing>
-        <property name="left_attach">2</property>
-        <property name="right_attach">3</property>
-        <property name="top_attach">3</property>
-        <property name="bottom_attach">4</property>
+        <property name="left_attach">4</property>
+        <property name="right_attach">5</property>
+        <property name="top_attach">2</property>
+        <property name="bottom_attach">3</property>
         <property name="x_options">GTK_FILL</property>
         <property name="y_options"/>
         <property name="x_padding">6</property>
         <property name="y_padding">6</property>
       </packing>
     </child>
+    <child>
+      <object class="GtkLabel" id="label35_2">
+        <property name="visible">True</property>
+        <property name="xalign">1</property>
+        <property name="label" translatable="yes">Unsigned 64 bit:</property>
+      </object>
+      <packing>
+        <property name="left_attach">4</property>
+        <property name="right_attach">5</property>
+        <property name="top_attach">1</property>
+        <property name="bottom_attach">2</property>
+        <property name="x_options">GTK_FILL</property>
+        <property name="y_options"/>
+        <property name="x_padding">6</property>
+        <property name="y_padding">6</property>
+      </packing>
+    </child>
+    <child>
+      <object class="GtkLabel" id="label34_2">
+        <property name="visible">True</property>
+        <property name="xalign">1</property>
+        <property name="label" translatable="yes">Signed 64 bit:</property>
+      </object>
+      <packing>
+        <property name="left_attach">4</property>
+        <property name="right_attach">5</property>
+        <property name="x_options">GTK_FILL</property>
+        <property name="y_options"/>
+        <property name="x_padding">6</property>
+        <property name="y_padding">6</property>
+      </packing>
+    </child>
+
     <child>
       <object class="GtkLabel" id="label36">
         <property name="visible">True</property>

--- a/src/gui/plugins/ConversionTablePlugin.cs
+++ b/src/gui/plugins/ConversionTablePlugin.cs
@@ -122,6 +122,8 @@ public class ConversionTable: Gtk.HBox
 	[Gtk.Builder.Object] Gtk.Entry Unsigned16bitEntry;
 	[Gtk.Builder.Object] Gtk.Entry Signed32bitEntry;
 	[Gtk.Builder.Object] Gtk.Entry Unsigned32bitEntry;
+	[Gtk.Builder.Object] Gtk.Entry Signed64bitEntry;
+	[Gtk.Builder.Object] Gtk.Entry Unsigned64bitEntry;
 	[Gtk.Builder.Object] Gtk.Entry Float32bitEntry;
 	[Gtk.Builder.Object] Gtk.Entry Float64bitEntry;
 	[Gtk.Builder.Object] Gtk.Entry HexadecimalEntry;
@@ -323,6 +325,11 @@ public class ConversionTable: Gtk.HBox
 		Signed32bitEntry.Text = "---";
 		Unsigned32bitEntry.Text = "---";
 	}
+	void Clear64bit()
+	{
+		Signed64bitEntry.Text = "---";
+		Unsigned64bitEntry.Text = "---";
+	}
 
 	void ClearFloat()
 	{
@@ -437,6 +444,42 @@ public class ConversionTable: Gtk.HBox
 		}
 	}
 
+	///<summary>Update the 64bit entries</summary>
+	void Update64bit(DataView dv)
+	{
+		long offset = dv.CursorOffset;
+
+		// make sure offset is valid
+		if (offset < dv.Buffer.Size - 7 && offset >= 0) {
+			long val = 0;
+
+            // create buffer for raw bytes
+			byte[] ba = new byte[8];
+
+			// fill byte[] according to endianess
+			if (littleEndian)
+				for (int i = 4; i < 8; i++)
+					ba[i] = dv.Buffer[offset+i];
+			else
+				for (int i = 0; i < 8; i++)
+					ba[7-i] = dv.Buffer[offset+i];
+
+			// set signed
+            val = BitConverter.ToInt64(ba);
+			Signed64bitEntry.Text = val.ToString();
+
+			// set unsigned
+			ulong uval = (ulong)val;
+			if (unsignedAsHex)
+				Unsigned64bitEntry.Text = string.Format("0x{0:x}", uval);
+			else
+				Unsigned64bitEntry.Text = uval.ToString();
+		}
+		else {
+			Clear64bit();
+		}
+	}
+
 	///<summary>Update the floating point entries</summary>
 	void UpdateFloat(DataView dv)
 	{
@@ -530,6 +573,7 @@ public class ConversionTable: Gtk.HBox
 		Update8bit(dv);
 		Update16bit(dv);
 		Update32bit(dv);
+		Update64bit(dv);
 		UpdateFloat(dv);
 		UpdateBases(dv);
 	}
@@ -543,6 +587,7 @@ public class ConversionTable: Gtk.HBox
 		Clear8bit();
 		Clear16bit();
 		Clear32bit();
+		Clear64bit();
 		ClearFloat();
 		ClearBases();
 	}


### PR DESCRIPTION
Adds a new column to the conversation widget to support singed and unsigned 64 bit integers.

This resolves Issue #34 