### PR TITLE
Show system-wide layouts

### DIFF
--- a/src/gui/dialogs/LayoutSelectionDialog.cs
+++ b/src/gui/dialogs/LayoutSelectionDialog.cs
@@ -93,7 +93,7 @@ public class LayoutSelectionDialog : Dialog {
 		TreeIter ti = ts.AppendValues(Catalog.GetString("System-wide Layouts"), string.Empty);
 
 		// fill list from bless data dir
-		string dataDir = FileResourcePath.GetDataPath("data");
+		string dataDir = FileResourcePath.GetDataPath(".");
 		if (Directory.Exists(dataDir)) {
 			string[] files = Directory.GetFiles(dataDir, "*.layout");
 			foreach (string s in files) {


### PR DESCRIPTION
The method `GetDataPath` resolves a path relative to the data directory, for example relative to the binary or by using the constant specified during configure. However that path already includes the `data` part of the directory, as this directory is assumed to contain `bless-default.layout`, so the additional `"data"` speficied here is superfluous, resulting in no system-layouts to be found. I am curious if there is a configuation where this code works.